### PR TITLE
Per-subnet DNS qualifying suffix (#17)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		kea-unbound
-PLUGIN_VERSION=		0.12.1
+PLUGIN_VERSION=		0.13.0
 PLUGIN_COMMENT=		Register Kea DHCP leases in Unbound DNS via DDNS (no core-file patching)
 PLUGIN_DEPENDS=		py313-dnspython
 PLUGIN_MAINTAINER=	james@jmuk.net

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ for as long as the lease is valid.
 
 - **Automatic** — dynamic leases are registered on grant/renew and removed on
   release/expiry, forward (A/AAAA) and reverse (PTR).
-- **Zero per-subnet setup** — DDNS is configured globally; you don't touch each subnet.
+- **Global by default, per-VLAN when you want it** — zero per-subnet setup out of the
+  box; optionally give each subnet its own domain so leases resolve under their VLAN's
+  zone (see *[Per-VLAN domains](#per-vlan-domains)*).
 - **Leaves your static DNS alone** — DHCP reservations and Host Overrides stay
   OPNsense's; the plugin never adds, deletes, or prunes them.
 - **Survives restarts** — records persist across Unbound restarts and reboots, no
@@ -42,7 +44,7 @@ for as long as the lease is valid.
 ## Install
 
 ```sh
-pkg add https://github.com/JameZUK/os-kea-unbound/releases/download/v0.12.1/os-kea-unbound-0.12.1.pkg
+pkg add https://github.com/JameZUK/os-kea-unbound/releases/download/v0.13.0/os-kea-unbound-0.13.0.pkg
 ```
 
 (Or [build it from source](docs/HOW-IT-WORKS.md#build-from-source).)
@@ -85,6 +87,26 @@ it — the plugin wires up Kea's DDNS, generates a TSIG key, and seeds existing 
 | Listener port † | 53535 | Loopback only. |
 
 † Shown only under **advanced mode** (toggle at the top of the form). The defaults are fine for almost everyone.
+
+### Per-VLAN domains
+
+By default every dynamic lease is qualified with a single suffix (the **Qualifying
+suffix** above, or the firewall's system domain). If you run multiple VLANs and want
+each to register under its **own** domain, just set a per-subnet **Domain name** — the
+plugin picks it up automatically:
+
+**Services → Kea DHCP → KEA DHCPv4 (or DHCPv6) → Subnets → (edit a subnet)**
+
+1. Untick **Automatically collect option data** — otherwise OPNsense overwrites the
+   domain with the firewall's system domain, so every VLAN looks the same.
+2. Set **Domain name** to that VLAN's domain, e.g. `iot.lan`.
+3. **Save**, then apply.
+
+Leases on that subnet now resolve under its own domain (e.g. `camera.iot.lan`), forward
+and reverse. Subnets you don't touch keep using the global suffix, so this is fully
+opt-in. Behind the scenes the plugin gives each subnet its own Kea
+`ddns-qualifying-suffix` and registers a DDNS forward zone per distinct domain, so every
+suffix is routed to the listener correctly.
 
 ## Status & Records
 

--- a/docs/design/issue-17-per-subnet-suffix.md
+++ b/docs/design/issue-17-per-subnet-suffix.md
@@ -1,0 +1,184 @@
+# Design: per-subnet DNS suffix (issue #17)
+
+**Status:** proposed
+**Issue:** [#17 — all leases get the dns suffix of the firewall](https://github.com/JameZUK/os-kea-unbound/issues/17)
+
+## Problem
+
+A site running multiple VLANs, each with its own domain (e.g. `iot.example.`,
+`lan.example.`, `guest.example.`), wants a dynamic lease to be registered under
+**its subnet's** domain. Today every lease is registered under a single,
+firewall-wide suffix, so per-VLAN DNS is broken.
+
+## Root cause
+
+`kea-config-sync.py` writes one **global** qualifying suffix at the `Dhcp4`/`Dhcp6`
+root of the generated Kea config, which every subnet inherits:
+
+```python
+# load_settings()
+suffix = _text(gen, "qualifying_suffix") or _text(root.find("./system"), "domain", "")
+# patch_dhcp()
+node["ddns-qualifying-suffix"] = s["suffix"]   # root scope → all subnets
+```
+
+Kea then qualifies every client name with that one suffix before sending the NCR,
+so the listener only ever sees `<host>.<firewall-domain>`.
+
+## Where the per-subnet domain is configured
+
+Both candidate sources already exist per subnet in OPNsense, in the **same subnet
+editor**: *Services → Kea DHCP → KEA DHCPv4 (or DHCPv6) → Subnets → edit a subnet*.
+They surface in the generated Kea config and in `config.xml` under
+`OPNsense/Kea/dhcp{4,6}/subnets/subnet{4,6}`:
+
+1. **DHCP "Domain name" option** — `option_data/domain_name` (option 15); appears in
+   the generated config as a per-subnet `option-data` entry
+   `{"name": "domain-name", "data": "<domain>"}`. This is the domain the VLAN's
+   clients receive.
+
+   ⚠️ **Gotcha that explains the symptom:** subnets default to **"Automatically
+   collect option data"** (`option_data_autocollect = 1`). With it on, OPNsense
+   auto-fills `domain-name` with the *firewall's* system domain. So to give a VLAN
+   its own domain the admin must untick auto-collect and set "Domain name"
+   explicitly. (Confirmed on the test box: dhcp4 subnet had `autocollect=1` and the
+   generated config carried `domain-name=internal`, the firewall domain.)
+
+2. **Native per-subnet DDNS "Qualifying suffix"** — `ddns_qualifying_suffix`; the
+   most direct expression of "what suffix DDNS should use for this subnet". It lives
+   under core OPNsense's native-DDNS UI (next to `ddns_forward_zone`), which this
+   plugin otherwise bypasses, so a user of this plugin may never have touched it.
+
+## Resolution rule (implemented)
+
+Per subnet, choose the suffix in this order (first non-empty wins):
+
+1. the subnet's `domain-name` option, else
+2. the current **global** suffix (plugin setting → firewall domain).
+
+The `domain-name` option is the clean choice because it is already present in the
+**generated** Kea config (a single source both code paths read) and is exactly what
+defines a VLAN's domain for its clients. Untouched subnets keep today's behaviour.
+
+The native per-subnet **DDNS "Qualifying suffix"** (`ddns_qualifying_suffix`) is a
+deliberate **future enhancement** (see open questions): honouring it would require
+correlating `config.xml` subnets to generated subnet-ids by CIDR, since core does
+not emit that field into the generated DHCP config. It is rarely set by users of
+this plugin (they bypass native DDNS), so v1 uses `domain-name` only.
+
+## Changes
+
+### 1. Shared helper — `lib/suffix.py` (new, pure)
+
+A dependency-free module both code paths import, so the resolution rule lives in one
+place. Reads the **generated** Kea config (single source of truth, already
+post-`option_data_autocollect`):
+
+- `subnet_suffix(subnet, global_suffix)` — domain-name option, else global fallback.
+- `iter_subnets(root, subnet_key)` — subnets incl. `shared-networks` (mirrors
+  `reservations()`).
+- `suffix_by_subnet_id(root, subnet_key, global_suffix)` — `{subnet_id: suffix}`;
+  subnet-id is what both the control socket and memfile CSV report per lease.
+- `norm()` / `clean()` — comparison form (lowercase, no dots) and storage form.
+
+### 2. `kea-config-sync.py` → `patch_dhcp()`
+
+For each subnet (incl. shared-network subnets), set its own
+`ddns-qualifying-suffix` from the resolution rule **only when it differs from the
+global**; keep writing the global at root as the fallback. Kea honours subnet scope
+over global, so untouched subnets are unaffected.
+
+### 3. `kea-config-sync.py` → `patch_d2()` — the important bit
+
+D2 matches **forward** zones by DNS suffix, and the `.` catch-all does **not** match
+a normal FQDN (confirmed on Kea 3.0.3 — `DHCP_DDNS_NO_MATCH`; see
+[[kea-native-ddns-facts]]). Today we register only the global suffix zone (+ a
+harmless `.`). With multiple suffixes we must register **a forward-ddns domain per
+distinct suffix**, each pointing at our listener (`127.0.0.1:<port>`) with our TSIG
+key:
+
+```python
+# main() collects the distinct suffixes once (global + every subnet domain-name
+# across both families) into s["suffixes"]; patch_d2 turns each into a zone:
+our_fwd = [catchall(norm(sfx) + ".") for sfx in s["suffixes"]] + [catchall(".")]
+```
+
+Reverse (`in-addr.arpa.`/`ip6.arpa.`) and TSIG are unchanged — reverse already
+matches by address and the key is shared. User-defined forward/reverse domains are
+still preserved exactly as today.
+
+### 4. `lib/kea_source.py` → `leases()` / `desired_records()`
+
+`desired_records()` qualifies bare lease hostnames with a single suffix to seed
+existing leases. Under per-subnet suffixes it must use **each lease's** suffix or it
+will seed a forward record under the wrong name **and** duplicate the live path's
+record. So:
+
+- `leases(family)` (and `_family_leases`) start returning `(hostname, ip, subnet_id)`
+  — subnet-id is present on both the control-socket lease and the CSV (`subnet_id`
+  column).
+- `desired_records()` builds the `subnet_suffix_map` once per family and calls
+  `host_fqdn(host, suffix_for[subnet_id])` per lease (fallback to global on an
+  unknown id). Already-qualified multi-label hostnames are still used verbatim by
+  `host_fqdn`, matching the live path.
+
+### 5. `lease-sync.py`
+
+No structural change — it consumes `desired_records()`, which now qualifies
+correctly per subnet. (It passes `settings["suffix"]` today; that becomes the global
+fallback that `desired_records` uses internally.)
+
+### 6. No change needed
+
+- **`clean.py`** — prunes by **address**, not name (deliberately: see
+  `is_stale_record`), so mixed suffixes can't cause false prunes. ✅
+- **The listener (`kea-unbound-ddns.py`)** — registers whatever FQDN Kea sends; it
+  never applies a suffix. ✅
+- **`start.py`** — already resolves the suffix only for logging; unaffected. ✅
+
+## Edge cases
+
+- **Subnet with no domain / auto-collect on** → falls back to the global suffix
+  (today's behaviour). No regression for single-domain sites.
+- **Shared networks** — walk `shared-networks[].subnet{4,6}` everywhere subnets are
+  enumerated (mirror `reservations()`).
+- **IPv6** — identical handling; v6 subnets often have no `domain-name` option, so
+  they lean on `ddns_qualifying_suffix` or the global fallback.
+- **Already-qualified hostnames** (client sent an FQDN) — unchanged; `host_fqdn`
+  uses them verbatim, so no double-suffixing.
+- **Suffix with/without trailing dot, case** — normalise once in the helper.
+
+## Testing
+
+Unit (off-box, no Kea):
+- `subnet_suffix_map`: precedence (ddns suffix > domain-name > global), shared
+  networks, missing fields, trailing-dot/case normalisation.
+- `patch_dhcp`: per-subnet `ddns-qualifying-suffix` set only when it differs from
+  global; global still written; idempotent (no rewrite when unchanged).
+- `patch_d2`: one forward zone per distinct suffix, all pointing at the listener
+  with the key; user domains preserved; idempotent.
+- `desired_records`: a two-subnet fixture with different domains qualifies each
+  lease correctly; unknown subnet-id falls back to global.
+
+Live (test box 192.168.0.216): add a second subnet with its own domain (untick
+auto-collect, set "Domain name"), take a lease on each VLAN, confirm each resolves
+under its own suffix forward + reverse, and that `clean` prunes nothing spurious.
+
+## Backward compatibility
+
+Single-domain sites are unaffected: with one suffix, the map collapses to the global
+value, `patch_dhcp` writes no per-subnet overrides, and `patch_d2` registers exactly
+the same one suffix zone as today. The feature is automatic (driven by existing
+per-subnet config) — no new plugin setting required, though a "honour per-subnet
+domains" toggle could be added later if an opt-out is wanted.
+
+## Open questions
+
+1. Should we also honour the native per-subnet DDNS **"Qualifying suffix"**
+   (`ddns_qualifying_suffix`)? Doing so means reading `config.xml` and joining its
+   subnets to generated subnet-ids by CIDR. (Proposed: add later if requested; if
+   both it and `domain-name` are set, `ddns_qualifying_suffix` would win as the more
+   DDNS-specific intent.)
+2. Should a per-subnet domain also drive the **reverse** zone delegation, or is the
+   shared `in-addr.arpa.`/`ip6.arpa.` catch-all (matched by address) sufficient?
+   (Proposed: catch-all is sufficient; PTRs don't depend on the forward suffix.)

--- a/src/opnsense/scripts/keaunbound/kea-config-sync.py
+++ b/src/opnsense/scripts/keaunbound/kea-config-sync.py
@@ -31,6 +31,9 @@ import tempfile
 import time
 import xml.etree.ElementTree as ET
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from lib import suffix as suffixmod  # noqa: E402
+
 CONFIG = "/conf/config.xml"
 KEA4 = "/usr/local/etc/kea/kea-dhcp4.conf"
 KEA6 = "/usr/local/etc/kea/kea-dhcp6.conf"
@@ -184,10 +187,22 @@ def patch_dhcp(path, root_key, s):
     # inheritance. Strip ONLY that false default (never an explicit user true) so
     # those subnets inherit the global value.
     subnet_key = "subnet4" if root_key == "Dhcp4" else "subnet6"
+    global_suffix = s.get("suffix") or ""
     for container in [node] + list(node.get("shared-networks", []) or []):
         for sn in (container.get(subnet_key, []) or []):
             if sn.get("ddns-send-updates") is False:
                 sn.pop("ddns-send-updates", None)
+            # Per-subnet qualifying suffix (issue #17): give the subnet its own
+            # ddns-qualifying-suffix (from its domain-name option) when it differs
+            # from the global; Kea honours subnet scope over the root value. When it
+            # matches the global, drop the key so the subnet just inherits (and so a
+            # later domain change can't leave a stale override — core never writes
+            # this key into the generated config, so any present is ours to manage).
+            sfx = suffixmod.subnet_suffix(sn, global_suffix)
+            if suffixmod.norm(sfx) and suffixmod.norm(sfx) != suffixmod.norm(global_suffix):
+                sn["ddns-qualifying-suffix"] = suffixmod.clean(sfx)
+            else:
+                sn.pop("ddns-qualifying-suffix", None)
     if json.dumps(node, sort_keys=True) == before:
         return False
     _write_atomic(path, json.dumps(cfg, indent=2))
@@ -211,17 +226,23 @@ def patch_d2(path, s):
 
     # Forward: Kea D2 matches forward domains by DNS suffix and does NOT honour
     # "." as a catch-all (it never matches a normal FQDN — confirmed on Kea 3.0.3:
-    # "DHCP_DDNS_NO_MATCH"). So register the qualifying-suffix zone explicitly —
-    # every name Kea emits is qualified into it (ddns-qualifying-suffix +
-    # ddns-replace-client-name). "." is kept only as a harmless fallback in case a
-    # future Kea honours it; today it simply never matches.
-    suffix_zone = (s["suffix"].strip(".").lower() + ".") if s.get("suffix") else None
-    our_fwd_names = {CATCHALL_FWD} | ({suffix_zone} if suffix_zone else set())
+    # "DHCP_DDNS_NO_MATCH"). So register a forward zone PER qualifying suffix — the
+    # global one plus every distinct per-subnet domain (issue #17). Every name Kea
+    # emits is qualified into its subnet's suffix (ddns-qualifying-suffix +
+    # ddns-replace-client-name), so each suffix needs its own zone pointed at our
+    # listener. "." is kept only as a harmless fallback in case a future Kea honours
+    # it; today it simply never matches.
+    suffix_zones = []
+    for sfx in (s.get("suffixes") or ([s["suffix"]] if s.get("suffix") else [])):
+        z = suffixmod.norm(sfx) + "." if suffixmod.norm(sfx) else ""
+        if z and z not in suffix_zones:
+            suffix_zones.append(z)
+    our_fwd_names = {CATCHALL_FWD} | set(suffix_zones)
     fwd = (d2.get("forward-ddns") or {}).get("ddns-domains") or []
     user_fwd = [d for d in fwd if d.get("name") not in our_fwd_names]
     if user_fwd:
         log("preserving %d user forward DDNS domain(s)" % len(user_fwd))
-    our_fwd = ([catchall(suffix_zone)] if suffix_zone else []) + [catchall(CATCHALL_FWD)]
+    our_fwd = [catchall(z) for z in suffix_zones] + [catchall(CATCHALL_FWD)]
     d2["forward-ddns"] = {"ddns-domains": user_fwd + our_fwd}
 
     # Reverse: keep user domains, (re)add our in-addr.arpa./ip6.arpa. catch-alls.
@@ -244,12 +265,33 @@ def patch_d2(path, s):
     return True
 
 
+def _collect_suffixes(global_suffix):
+    """Every distinct qualifying suffix to register a D2 forward zone for: the
+    global one plus each subnet's domain-name across both families (issue #17).
+    Order: global first, then first-seen per-subnet; de-duped case-insensitively."""
+    out, seen = [], set()
+
+    def add(sfx):
+        n = suffixmod.norm(sfx)
+        if n and n not in seen:
+            seen.add(n)
+            out.append(suffixmod.clean(sfx))
+
+    add(global_suffix)
+    for path, key, subnet_key in ((KEA4, "Dhcp4", "subnet4"), (KEA6, "Dhcp6", "subnet6")):
+        root = (_load_json(path) or {}).get(key) or {}
+        for sn in suffixmod.iter_subnets(root, subnet_key):
+            add(suffixmod.subnet_suffix(sn, global_suffix))
+    return out
+
+
 def main():
     s = load_settings()
     if s is None:
         print("keaunbound: disabled/unreadable — no DDNS injection")
         return 0
     s["d2_ip"], s["d2_port"] = _d2_listen(D2)
+    s["suffixes"] = _collect_suffixes(s["suffix"])
     changed = []
     if patch_dhcp(KEA4, "Dhcp4", s):
         changed.append("dhcp4")

--- a/src/opnsense/scripts/keaunbound/lib/kea_source.py
+++ b/src/opnsense/scripts/keaunbound/lib/kea_source.py
@@ -14,6 +14,7 @@ import xml.etree.ElementTree as ET
 
 from . import records as R
 from . import kea_ctrl
+from . import suffix as suffixmod
 
 CONFIG = "/conf/config.xml"
 KEA4 = "/usr/local/etc/kea/kea-dhcp4.conf"
@@ -109,7 +110,8 @@ def leases_csv(family):
                     continue
     except OSError:
         return []
-    return [(r.get("hostname", ""), addr) for addr, r in seen.items() if r.get("hostname")]
+    return [(r.get("hostname", ""), addr, r.get("subnet_id"))
+            for addr, r in seen.items() if r.get("hostname")]
 
 
 # A memfile CSV persists on disk after Kea stops, so its mere existence is not
@@ -146,7 +148,7 @@ def _family_leases(family):
                 continue
             host, addr = lease.get("hostname"), lease.get("ip-address")
             if host and addr:
-                out.append((host, addr))
+                out.append((host, addr, lease.get("subnet-id")))
         return out, True
     if _csv_fresh(family):
         return leases_csv(family), True
@@ -154,8 +156,20 @@ def _family_leases(family):
 
 
 def leases(family):
-    """(hostname, ip) for active leases via control socket, fresh-CSV fallback."""
+    """(hostname, ip, subnet_id) for active leases via control socket, fresh-CSV
+    fallback. subnet_id maps a lease to its per-subnet qualifying suffix (issue #17)
+    and may be None when the source doesn't report it."""
     return _family_leases(family)[0]
+
+
+def _suffix_map(family, global_suffix):
+    """{subnet_id: qualifying_suffix} for a family, from the generated Kea config.
+    Empty when the config is absent/unreadable -> callers fall back to the global."""
+    path = KEA4 if family == "4" else KEA6
+    cfg = _load_json(path) or {}
+    root = cfg.get("Dhcp4" if family == "4" else "Dhcp6") or {}
+    subnet_key = "subnet4" if family == "4" else "subnet6"
+    return suffixmod.suffix_by_subnet_id(root, subnet_key, global_suffix)
 
 
 def lease_source_ok(family):
@@ -184,7 +198,7 @@ def clean_inputs():
         prunable[fam] = source_ok and resv_ok
         if not resv_ok:
             continue
-        for _host, ip in leases_list:
+        for _host, ip, _sid in leases_list:
             n = R._norm_ip(ip)
             if n is not None and n not in resv:
                 live[fam].add(n)
@@ -220,12 +234,22 @@ def desired_records(suffix):
         resv, ok = _reserved_for_family(fam)
         if not ok:
             continue  # config present but unreadable -> skip this family
-        for host, ip in leases(fam):
+        # Per-subnet qualifying suffix (issue #17): qualify each lease with its own
+        # subnet's domain so the seeded name matches what the live DDNS path (Kea)
+        # writes. Unknown/absent subnet-id falls back to the global suffix.
+        smap = _suffix_map(fam, suffix)
+        for host, ip, sid in leases(fam):
             n = R._norm_ip(ip)
             if n is None or n in resv:
                 continue  # reservation -> OPNsense's, not ours
             try:
-                name = R.host_fqdn(host, suffix)
+                sfx = suffix
+                if sid is not None:
+                    try:
+                        sfx = smap.get(int(sid), suffix)
+                    except (TypeError, ValueError):
+                        sfx = suffix
+                name = R.host_fqdn(host, sfx)
                 if not name:
                     continue
                 recs.append(R.Record(name, 3600, R.rrtype_for_ip(ip), ip))

--- a/src/opnsense/scripts/keaunbound/lib/suffix.py
+++ b/src/opnsense/scripts/keaunbound/lib/suffix.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright (c) 2026 James (JameZUK)
+"""
+Per-subnet DDNS qualifying-suffix resolution (issue #17).
+
+A site with multiple VLANs wants each dynamic lease registered under *its* subnet's
+domain, not one firewall-wide suffix. The per-subnet domain is taken from the
+subnet's DHCP "Domain name" option (option 15), which OPNsense writes into the
+generated Kea config as an `option-data` entry. When a subnet has no domain-name
+option we fall back to the global suffix (plugin setting -> firewall domain), so
+single-domain sites are unaffected.
+
+Pure helpers (no I/O, no third-party deps) so both the kea_sync injector
+(kea-config-sync.py) and the lease seeder (kea_source.py) share one resolution
+rule and stay in lock-step.
+"""
+
+
+def norm(s):
+    """Comparison form of a suffix: lowercase, no surrounding whitespace or dots.
+
+    DNS suffixes are case-insensitive and the trailing dot is optional, so two
+    suffixes are "the same zone" iff their norm() forms match."""
+    return (s or "").strip().strip(".").lower()
+
+
+def clean(s):
+    """Storage form written into the Kea config: trimmed, no trailing dot, original
+    case preserved (Kea lowercases on the wire; we keep the admin's spelling)."""
+    return (s or "").strip().strip(".")
+
+
+def domain_name_option(subnet):
+    """The subnet's DHCP domain-name option value, or '' if it has none."""
+    for opt in (subnet.get("option-data") or []):
+        if opt.get("name") == "domain-name" and (opt.get("data") or "").strip():
+            return opt["data"].strip()
+    return ""
+
+
+def subnet_suffix(subnet, global_suffix):
+    """Resolved DDNS suffix for one subnet dict from the generated Kea config:
+    its domain-name option if set, else the global suffix ('' if neither)."""
+    return domain_name_option(subnet) or (global_suffix or "")
+
+
+def iter_subnets(root, subnet_key):
+    """Yield every subnet dict under a Dhcp4/Dhcp6 root, including those nested in
+    shared-networks (mirrors how reservations are enumerated)."""
+    for sn in (root.get(subnet_key) or []):
+        yield sn
+    for net in (root.get("shared-networks") or []):
+        for sn in (net.get(subnet_key) or []):
+            yield sn
+
+
+def suffix_by_subnet_id(root, subnet_key, global_suffix):
+    """{subnet_id(int): resolved_suffix} for one family. subnet-id is the key both
+    the control socket and the memfile CSV report per lease, so the seeder can map a
+    lease straight to its suffix."""
+    out = {}
+    for sn in iter_subnets(root, subnet_key):
+        sid = sn.get("id")
+        if sid is None:
+            continue
+        try:
+            out[int(sid)] = subnet_suffix(sn, global_suffix)
+        except (TypeError, ValueError):
+            continue
+    return out

--- a/tests/unit/test_config_sync.py
+++ b/tests/unit/test_config_sync.py
@@ -42,6 +42,72 @@ def test_patch_dhcp_global_and_subnet_override(tmp_path):
     assert m.patch_dhcp(str(p), "Dhcp4", SETTINGS) is False  # idempotent
 
 
+def test_patch_dhcp_per_subnet_suffix(tmp_path):
+    # issue #17: a subnet with its own domain-name option gets a per-subnet
+    # ddns-qualifying-suffix; one matching the global, or with no domain, inherits.
+    m = load_injector(tmp_path)
+    p = tmp_path / "k4.json"
+    json.dump({"Dhcp4": {"subnet4": [
+        {"subnet": "10.0.0.0/24",                                  # own domain -> override
+         "option-data": [{"name": "domain-name", "data": "iot.lan"}]},
+        {"subnet": "10.1.0.0/24",                                  # == global -> inherit
+         "option-data": [{"name": "domain-name", "data": "home.lan"}]},
+        {"subnet": "10.2.0.0/24"},                                 # no domain -> inherit
+    ]}}, open(p, "w"))
+    assert m.patch_dhcp(str(p), "Dhcp4", SETTINGS) is True         # SETTINGS suffix=home.lan
+    subs = json.load(open(p))["Dhcp4"]["subnet4"]
+    assert subs[0]["ddns-qualifying-suffix"] == "iot.lan"          # differs -> set
+    assert "ddns-qualifying-suffix" not in subs[1]                 # equals global -> inherit
+    assert "ddns-qualifying-suffix" not in subs[2]                 # no domain -> inherit
+    assert m.patch_dhcp(str(p), "Dhcp4", SETTINGS) is False        # idempotent
+
+
+def test_patch_dhcp_per_subnet_suffix_in_shared_network(tmp_path):
+    # shared-network subnets are covered too.
+    m = load_injector(tmp_path)
+    p = tmp_path / "k4.json"
+    json.dump({"Dhcp4": {"subnet4": [], "shared-networks": [{"name": "sn", "subnet4": [
+        {"subnet": "10.5.0.0/24",
+         "option-data": [{"name": "domain-name", "data": "guest.lan"}]}]}]}}, open(p, "w"))
+    assert m.patch_dhcp(str(p), "Dhcp4", SETTINGS) is True
+    sn = json.load(open(p))["Dhcp4"]["shared-networks"][0]["subnet4"][0]
+    assert sn["ddns-qualifying-suffix"] == "guest.lan"
+
+
+def test_patch_d2_multi_suffix(tmp_path):
+    # issue #17: one forward zone per distinct suffix in s["suffixes"], all pointed
+    # at our listener with our key; "." kept as the harmless fallback.
+    m = load_injector(tmp_path)
+    p = tmp_path / "d2.json"
+    json.dump({"DhcpDdns": {"forward-ddns": {"ddns-domains": []},
+                            "reverse-ddns": {"ddns-domains": []}, "tsig-keys": []}}, open(p, "w"))
+    s = dict(SETTINGS, suffixes=["home.lan", "iot.lan", "guest.lan"])
+    assert m.patch_d2(str(p), s) is True
+    fwd = {x["name"]: x for x in json.load(open(p))["DhcpDdns"]["forward-ddns"]["ddns-domains"]}
+    for z in ("home.lan.", "iot.lan.", "guest.lan.", "."):
+        assert z in fwd
+        assert fwd[z]["dns-servers"][0] == {"ip-address": "127.0.0.1", "port": 53535}
+        assert fwd[z]["key-name"] == "keaunbound."
+    assert m.patch_d2(str(p), s) is False                          # idempotent
+
+
+def test_collect_suffixes(tmp_path):
+    # global first, then per-subnet domains across both families, deduped (ci).
+    m = load_injector(tmp_path)
+    m.KEA4 = str(tmp_path / "k4.json")
+    m.KEA6 = str(tmp_path / "k6.json")
+    json.dump({"Dhcp4": {"subnet4": [
+        {"option-data": [{"name": "domain-name", "data": "iot.lan"}]},
+        {"option-data": [{"name": "domain-name", "data": "Home.LAN"}]},   # dup of global (ci)
+    ]}}, open(m.KEA4, "w"))
+    json.dump({"Dhcp6": {"subnet6": [
+        {"option-data": [{"name": "domain-name", "data": "v6.lan"}]}]}}, open(m.KEA6, "w"))
+    out = m._collect_suffixes("home.lan")
+    assert out[0] == "home.lan"                       # global first
+    assert "iot.lan" in out and "v6.lan" in out
+    assert sum(1 for x in out if x.lower() == "home.lan") == 1   # deduped case-insensitively
+
+
 def test_patch_dhcp_merges_existing_ddns_block(tmp_path):
     # a user's extra dhcp-ddns keys must be preserved, only the connection params
     # we require are forced (non-destructive merge, not a clobber).

--- a/tests/unit/test_kea_source.py
+++ b/tests/unit/test_kea_source.py
@@ -37,7 +37,7 @@ def test_leases_csv_filters_expired_and_state(tmp_path):
         f"10.0.0.52,aa,bb,4000,{future},1,1,1,declined52,1,,0\n"
     )
     kea_source.CSV4 = str(c)
-    addrs = {a for _, a in kea_source.leases_csv("4")}
+    addrs = {a for _, a, _ in kea_source.leases_csv("4")}
     assert "10.0.0.50" in addrs
     assert "10.0.0.51" not in addrs and "10.0.0.52" not in addrs
 
@@ -49,7 +49,7 @@ def test_desired_records_dynamic_only(monkeypatch):
     monkeypatch.setattr(kea_source, "_reserved_for_family",
                         lambda f: ({"10.0.0.9"}, True) if f == "4" else (set(), True))
     monkeypatch.setattr(kea_source, "leases",
-                        lambda f: [("dyn", "10.0.0.5"), ("resv", "10.0.0.9")] if f == "4" else [])
+                        lambda f: [("dyn", "10.0.0.5", 1), ("resv", "10.0.0.9", 1)] if f == "4" else [])
     lines = [r.local_data_line() for r in kea_source.desired_records("home.lan")]
     assert any('dyn.home.lan. 3600 IN A 10.0.0.5' in ln for ln in lines)         # forward
     assert any('5.0.0.10.in-addr.arpa. 3600 IN PTR dyn.home.lan.' in ln for ln in lines)  # reverse
@@ -63,10 +63,25 @@ def test_desired_records_skips_family_with_unreadable_config(monkeypatch):
     monkeypatch.setattr(kea_source, "_reserved_for_family",
                         lambda f: (set(), False) if f == "4" else (set(), True))
     monkeypatch.setattr(kea_source, "leases",
-                        lambda f: [("v4host", "10.0.0.5")] if f == "4" else [("v6host", "2001:db8::5")])
+                        lambda f: [("v4host", "10.0.0.5", 1)] if f == "4" else [("v6host", "2001:db8::5", 1)])
     lines = [r.local_data_line() for r in kea_source.desired_records("home.lan")]
     assert not any("v4host" in ln or "10.0.0.5" in ln for ln in lines)  # v4 skipped
     assert any("v6host" in ln for ln in lines)                          # v6 still emitted
+
+
+def test_desired_records_per_subnet_suffix(monkeypatch):
+    # issue #17: each lease is qualified with its own subnet's suffix; an unknown
+    # subnet-id (or one absent from the map) falls back to the global suffix.
+    monkeypatch.setattr(kea_source, "_reserved_for_family", lambda f: (set(), True))
+    monkeypatch.setattr(kea_source, "leases",
+                        lambda f: ([("a", "10.0.0.5", 1), ("b", "10.1.0.5", 2),
+                                    ("c", "10.2.0.5", 99)] if f == "4" else []))
+    monkeypatch.setattr(kea_source, "_suffix_map",
+                        lambda fam, g: {1: "vlan1.lan", 2: "vlan2.lan"} if fam == "4" else {})
+    lines = [r.local_data_line() for r in kea_source.desired_records("global.lan")]
+    assert any("a.vlan1.lan. 3600 IN A 10.0.0.5" in ln for ln in lines)
+    assert any("b.vlan2.lan. 3600 IN A 10.1.0.5" in ln for ln in lines)
+    assert any("c.global.lan. 3600 IN A 10.2.0.5" in ln for ln in lines)  # unknown sid -> global
 
 
 def test_leases_csv_skips_ia_pd(tmp_path):
@@ -80,7 +95,7 @@ def test_leases_csv_skips_ia_pd(tmp_path):
         f"2001:db8:abcd::,aa,4000,{future},1,4000,2,1,56,1,1,deleg-pd,0,,0\n"
     )
     kea_source.CSV6 = str(c)
-    addrs = {a for _, a in kea_source.leases_csv("6")}
+    addrs = {a for _, a, _ in kea_source.leases_csv("6")}
     assert "2001:db8::50" in addrs            # IA_NA host kept
     assert "2001:db8:abcd::" not in addrs     # IA_PD prefix skipped
 
@@ -112,7 +127,7 @@ def test_desired_records_key_identity(monkeypatch):
     # see test_clean.py. This only covers desired_records' own output.)
     monkeypatch.setattr(kea_source, "_reserved_for_family", lambda f: (set(), True))
     monkeypatch.setattr(kea_source, "leases",
-                        lambda f: [("keep", "10.0.0.5")] if f == "4" else [])
+                        lambda f: [("keep", "10.0.0.5", 1)] if f == "4" else [])
     desired = {r.key() for r in kea_source.desired_records("home.lan")}
     assert ("keep.home.lan.", "A", "10.0.0.5") in desired
     assert ("5.0.0.10.in-addr.arpa.", "PTR", "keep.home.lan.") in desired
@@ -141,7 +156,7 @@ def test_leases_socket_skips_ia_pd(monkeypatch):
         {"hostname": "deleg-pd", "ip-address": "2001:db8:abcd::", "state": 0, "type": "IA_PD"},
     ]}}
     monkeypatch.setattr(kea_source.kea_ctrl, "send_command", lambda *a, **k: resp)
-    out = dict(kea_source.leases("6"))
+    out = {h: ip for h, ip, _sid in kea_source.leases("6")}
     assert out.get("host-na") == "2001:db8::50"
     assert "deleg-pd" not in out
 
@@ -151,8 +166,8 @@ def test_clean_inputs_single_fetch(monkeypatch):
     monkeypatch.setattr(kea_source, "_reserved_for_family",
                         lambda f: ({"10.0.0.9"}, True) if f == "4" else (set(), True))
     monkeypatch.setattr(kea_source, "_family_leases",
-                        lambda f: ([("dyn", "10.0.0.5"), ("resv", "10.0.0.9")], True)
-                        if f == "4" else ([("v6", "2001:db8::5")], True))
+                        lambda f: ([("dyn", "10.0.0.5", 1), ("resv", "10.0.0.9", 1)], True)
+                        if f == "4" else ([("v6", "2001:db8::5", 1)], True))
     live, prunable = kea_source.clean_inputs()
     assert live["4"] == {"10.0.0.5"}          # reserved 10.0.0.9 excluded
     assert live["6"] == {"2001:db8::5"}
@@ -170,7 +185,7 @@ def test_clean_inputs_unconfirmed_source_not_prunable(monkeypatch):
 def test_clean_inputs_unreadable_reserved_not_prunable(monkeypatch):
     # reserved config present-but-unreadable -> not prunable, no live IPs collected
     monkeypatch.setattr(kea_source, "_reserved_for_family", lambda f: (set(), False))
-    monkeypatch.setattr(kea_source, "_family_leases", lambda f: ([("h", "10.0.0.5")], True))
+    monkeypatch.setattr(kea_source, "_family_leases", lambda f: ([("h", "10.0.0.5", 1)], True))
     live, prunable = kea_source.clean_inputs()
     assert prunable == {"4": False, "6": False}
     assert live["4"] == set() and live["6"] == set()
@@ -180,9 +195,10 @@ def test_family_leases_socket_vs_fresh_csv(monkeypatch, tmp_path):
     # socket result==0 -> authoritative; socket down + stale CSV -> ([], False)
     monkeypatch.setattr(kea_source.kea_ctrl, "send_command",
                         lambda *a, **k: {"result": 0, "arguments": {"leases": [
-                            {"hostname": "h", "ip-address": "10.0.0.5", "state": 0}]}})
+                            {"hostname": "h", "ip-address": "10.0.0.5", "state": 0,
+                             "subnet-id": 1}]}})
     out, ok = kea_source._family_leases("4")
-    assert ok is True and ("h", "10.0.0.5") in out
+    assert ok is True and ("h", "10.0.0.5", 1) in out
     monkeypatch.setattr(kea_source.kea_ctrl, "send_command", lambda *a, **k: None)
     kea_source.CSV4 = str(tmp_path / "absent.csv")
     assert kea_source._family_leases("4") == ([], False)
@@ -199,7 +215,7 @@ def test_family_leases_fresh_csv_fallback(monkeypatch, tmp_path):
     kea_source.CSV4 = str(c)  # just written -> fresh
     out, ok = kea_source._family_leases("4")
     assert ok is True
-    assert ("csvhost", "10.0.0.7") in out
+    assert ("csvhost", "10.0.0.7", "1") in out   # subnet_id from CSV (string)
 
 
 def test_load_settings(tmp_path):

--- a/tests/unit/test_suffix.py
+++ b/tests/unit/test_suffix.py
@@ -1,0 +1,43 @@
+from lib import suffix as S
+
+
+def test_norm_and_clean():
+    assert S.norm("  Home.LAN.  ") == "home.lan"
+    assert S.norm("") == "" and S.norm(None) == ""
+    assert S.clean("  iot.lan.  ") == "iot.lan"   # trims + drops trailing dot, keeps case
+    assert S.clean("IoT.LAN") == "IoT.LAN"
+
+
+def test_domain_name_option():
+    sn = {"option-data": [{"name": "routers", "data": "10.0.0.1"},
+                          {"name": "domain-name", "data": "iot.lan"}]}
+    assert S.domain_name_option(sn) == "iot.lan"
+    assert S.domain_name_option({"option-data": []}) == ""
+    assert S.domain_name_option({}) == ""
+    # blank domain-name is treated as unset
+    assert S.domain_name_option({"option-data": [{"name": "domain-name", "data": "  "}]}) == ""
+
+
+def test_subnet_suffix_precedence():
+    own = {"option-data": [{"name": "domain-name", "data": "iot.lan"}]}
+    assert S.subnet_suffix(own, "home.lan") == "iot.lan"          # option wins
+    assert S.subnet_suffix({}, "home.lan") == "home.lan"          # fallback to global
+    assert S.subnet_suffix({}, "") == ""                          # neither
+
+
+def test_iter_subnets_includes_shared_networks():
+    root = {"subnet4": [{"id": 1}],
+            "shared-networks": [{"subnet4": [{"id": 2}, {"id": 3}]}]}
+    ids = [sn.get("id") for sn in S.iter_subnets(root, "subnet4")]
+    assert ids == [1, 2, 3]
+
+
+def test_suffix_by_subnet_id():
+    root = {"subnet4": [
+        {"id": 1, "option-data": [{"name": "domain-name", "data": "iot.lan"}]},
+        {"id": 2},                                   # no domain -> global
+        {"option-data": [{"name": "domain-name", "data": "x"}]},  # no id -> skipped
+    ], "shared-networks": [{"subnet4": [
+        {"id": 5, "option-data": [{"name": "domain-name", "data": "guest.lan"}]}]}]}
+    m = S.suffix_by_subnet_id(root, "subnet4", "home.lan")
+    assert m == {1: "iot.lan", 2: "home.lan", 5: "guest.lan"}


### PR DESCRIPTION
Closes #17.

## What

Register each dynamic lease under **its own subnet's domain** instead of one firewall-wide suffix. A site with multiple VLANs (e.g. `iot.lan`, `guest.lan`) now gets per-VLAN DNS.

The per-subnet domain comes from the subnet's DHCP **"Domain name"** option (option 15) in the generated Kea config, falling back to the global suffix — so single-domain sites are byte-for-byte unchanged.

> Note: subnets default to **"Automatically collect option data"**, which auto-fills `domain-name` with the *firewall's* domain. To give a VLAN its own domain, untick auto-collect and set "Domain name" per subnet.

## Changes

- **`lib/suffix.py`** (new, pure) — one shared resolver (domain-name option → global), covers `shared-networks`, builds a `subnet-id → suffix` map.
- **`kea-config-sync.py`**
  - `patch_dhcp`: write per-subnet `ddns-qualifying-suffix` when it differs from global (Kea honours subnet scope over root).
  - `patch_d2`: register **one forward-DDNS zone per distinct suffix**, each pointed at our listener with our TSIG key. (D2 matches forward zones by suffix; `.` never matches a real FQDN.)
- **`lib/kea_source.py`** — `leases()` now carries `subnet-id`; `desired_records()` qualifies each seeded lease with its subnet's suffix so seeds match the live DDNS path (no wrong-name duplicates).
- **No change needed:** `clean.py` (prunes by IP, not name) and the listener (registers whatever FQDN Kea sends).

Design doc: `docs/design/issue-17-per-subnet-suffix.md`. Native per-subnet DDNS "Qualifying suffix" field is a noted follow-up (needs config.xml↔subnet-id correlation).

## Testing

- **96 unit tests pass** — incl. multi-subnet/multi-domain cases (`test_suffix.py`, `test_config_sync.py`, `test_kea_source.py`).
- **Live integration suite on a real OPNsense 26.1.9 box: 41/41** (listener_live 10/0 + extra_live 31/0) — no listener regression.
- **Live multi-VLAN end-to-end** through the real `kea_sync`: two subnets with distinct domains (`iot.lan`, `guest.lan`) each got their own `ddns-qualifying-suffix`; D2 got all four zones; seeder map resolved `{1: iot.lan, 2: guest.lan}`; live DDNS registered `camera.iot.lan` and `phone.guest.lan` simultaneously and removed both. Reserved IPs were correctly skipped (A18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)