### PR TITLE
Add 'Remove stale records' button to Status page (#20)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		kea-unbound
-PLUGIN_VERSION=		0.13.0
+PLUGIN_VERSION=		0.14.0
 PLUGIN_COMMENT=		Register Kea DHCP leases in Unbound DNS via DDNS (no core-file patching)
 PLUGIN_DEPENDS=		py313-dnspython
 PLUGIN_MAINTAINER=	james@jmuk.net

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ for as long as the lease is valid.
 ## Install
 
 ```sh
-pkg add https://github.com/JameZUK/os-kea-unbound/releases/download/v0.13.0/os-kea-unbound-0.13.0.pkg
+pkg add https://github.com/JameZUK/os-kea-unbound/releases/download/v0.14.0/os-kea-unbound-0.14.0.pkg
 ```
 
 (Or [build it from source](docs/HOW-IT-WORKS.md#build-from-source).)
@@ -111,7 +111,15 @@ suffix is routed to the listener correctly.
 ## Status & Records
 
 **Status** shows listener health, the registered record count, TSIG state, the
-effective qualifying suffix, a **Sync now** button, and a live activity log.
+effective qualifying suffix, a **Sync now** button, a **Remove stale records** button,
+and a live activity log.
+
+**Remove stale records** prunes any records Unbound still holds that Kea no longer knows
+about (an expired or released lease, or a host that moved to another VLAN). It applies
+the removals to the running Unbound straight away, so there's no need to stop the plugin
+or restart Unbound. It's safe in an HA setup: if it can't confirm a current lease list
+from Kea it does nothing rather than risk removing good records, and it refuses to bulk
+remove an unusually large number at once.
 
 **Records** lists every registered record, enriched with the matching Kea lease detail
 (hostname, MAC/DUID, subnet, source, expiry, TTL) — searchable and sortable.

--- a/src/opnsense/mvc/app/controllers/OPNsense/KeaUnbound/Api/ServiceController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/KeaUnbound/Api/ServiceController.php
@@ -81,4 +81,20 @@ class ServiceController extends ApiMutableServiceControllerBase
         $output = (new Backend())->configdRun('keaunbound sync');
         return ['status' => 'ok', 'output' => trim((string)$output)];
     }
+
+    /**
+     * Prune stale records — entries still in Unbound that Kea no longer knows
+     * about (expired/released leases, hosts that moved VLAN) — and apply the
+     * removals to the running Unbound with no restart (the Status page
+     * "Remove stale records" button). Safe by design: clean aborts rather than
+     * mass-evict if no Kea lease source is confirmed this run.
+     */
+    public function cleanAction()
+    {
+        if (!$this->request->isPost()) {
+            return ['status' => 'failed'];
+        }
+        $output = (new Backend())->configdRun('keaunbound clean');
+        return ['status' => 'ok', 'output' => trim((string)$output)];
+    }
 }

--- a/src/opnsense/mvc/app/views/OPNsense/KeaUnbound/status.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/KeaUnbound/status.volt
@@ -69,6 +69,15 @@
             $("#syncAct_progress").addClass("fa fa-spinner fa-pulse");
             ajaxCall("/api/keaunbound/service/sync", {}, function (data, status) {
                 $("#syncAct_progress").removeClass("fa fa-spinner fa-pulse");
+                if (data && data.output) { $("#actResult").text(data.output); }
+                refreshStatus();
+            });
+        });
+        $("#cleanAct").click(function () {
+            $("#cleanAct_progress").addClass("fa fa-spinner fa-pulse");
+            ajaxCall("/api/keaunbound/service/clean", {}, function (data, status) {
+                $("#cleanAct_progress").removeClass("fa fa-spinner fa-pulse");
+                if (data && data.output) { $("#actResult").text(data.output); }
                 refreshStatus();
             });
         });
@@ -96,6 +105,15 @@
             {{ lang._('Re-seed existing Kea leases and reservations into Unbound.') }}
         </span>
     </div>
+    <div style="padding: 0.5em 8px 0;">
+        <button class="btn btn-default" id="cleanAct" type="button">
+            <b>{{ lang._('Remove stale records') }}</b> <i id="cleanAct_progress"></i>
+        </button>
+        <span class="text-muted" style="margin-left:1em;">
+            {{ lang._('Prune records Kea no longer knows about (no restart needed).') }}
+        </span>
+    </div>
+    <div id="actResult" class="text-muted" style="padding: 0.5em 8px 0; font-style:italic;"></div>
 </div>
 
 <div class="content-box" style="margin-top:1em; padding:1em;">


### PR DESCRIPTION
Closes #20.

## What
Adds a **Remove stale records** button to the Status page that surfaces the existing `keaunbound clean` backstop, so stale records — leases gone from Kea (expired/released, or a host that moved VLAN) but still in Unbound — can be pruned on demand **without stopping the plugin and restarting Unbound**.

## Changes
- `Api/ServiceController::cleanAction()` → configd `keaunbound clean` (POST-guarded, mirrors `syncAction`).
- Status page button **Remove stale records**, reporting the result line; bumps `PLUGIN_VERSION` to 0.14.0.
- README documents the button.

No backend logic change: `clean.py` already prunes by address, applies removals to the running Unbound via `local_data_remove` (no restart), skips OPNsense-owned/static names, and refuses to mass-evict when no Kea lease source is confirmed (HA-safe).

## Testing
- 96 unit tests pass.
- **Test box:** injected 3 live leases, deleted one to make it stale; the button's `keaunbound clean` pruned only the stale A+PTR from Unbound's runtime (others kept, gamma → NXDOMAIN) with the **unbound pid unchanged (no restart)**. API route returns 302 like `service/sync`.
- **Live prod (0.14.0):** 234 records / 156 v4 + 29 v6 leases → `clean` reported "no stale records", count unchanged (no false prunes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
