### PR TITLE
Rebuild package for OPNsense 26.7 / FreeBSD 15 (#22)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		kea-unbound
-PLUGIN_VERSION=		0.14.0
+PLUGIN_VERSION=		0.14.1
 PLUGIN_COMMENT=		Register Kea DHCP leases in Unbound DNS via DDNS (no core-file patching)
 PLUGIN_DEPENDS=		py313-dnspython
 PLUGIN_MAINTAINER=	james@jmuk.net

--- a/README.md
+++ b/README.md
@@ -43,11 +43,22 @@ for as long as the lease is valid.
 
 ## Install
 
+**OPNsense 26.7+ (FreeBSD 15):**
+
+```sh
+pkg add https://github.com/JameZUK/os-kea-unbound/releases/download/v0.14.1/os-kea-unbound-0.14.1.pkg
+```
+
+**OPNsense 26.1 (FreeBSD 14):**
+
 ```sh
 pkg add https://github.com/JameZUK/os-kea-unbound/releases/download/v0.14.0/os-kea-unbound-0.14.0.pkg
 ```
 
-(Or [build it from source](docs/HOW-IT-WORKS.md#build-from-source).)
+Packages are architecture-stamped, so use the one that matches your release — a
+FreeBSD 15 package won't install on FreeBSD 14 and vice versa. The two builds are
+otherwise identical. (Or [build it from source](docs/HOW-IT-WORKS.md#build-from-source),
+which always matches your running system.)
 
 ## Migrating from the old v3.x plugin
 


### PR DESCRIPTION
Fixes #22.

OPNsense 26.7 rebases onto **FreeBSD 15**, so its package ABI is `FreeBSD:15:amd64`. The `v0.14.0` release asset was built on FreeBSD 14, so `pkg add` rejects it on 26.7:

```
pkg: wrong architecture: FreeBSD:14:amd64 instead of FreeBSD:15:amd64
```

### What this changes
- **No plugin code changes.** This is a pure rebuild on 26.7 producing a `FreeBSD:15:amd64` package.
- `PLUGIN_VERSION` → `0.14.1`.
- README documents both install URLs: 26.7/FreeBSD 15 → `v0.14.1`, 26.1/FreeBSD 14 → `v0.14.0`. The two builds are byte-identical apart from the ABI stamp.

### Verified on OPNsense 26.7.1_1 (FreeBSD 15.1, PHP 8.5)
- Package stamped `abi=FreeBSD:15:amd64` / `arch=freebsd:15:x86:64`.
- Reporter's exact command reproduced: clean `pkg delete` then plain `pkg add <file>` (no `-f`) → installs, no architecture error.
- `py313-dnspython` still correct (26.7 ships `python313` / `py313-dnspython 2.8.0`).
- All KeaUnbound PHP lints clean under PHP 8.5; listener runs; Kea D2 DDNS wired to the listener on :53535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)